### PR TITLE
[wip] Add pub sub panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ envs/
 lib/
 node_modules/
 Untitled*
+.vscode

--- a/packages/jupyterlab-dat/src/css.ts
+++ b/packages/jupyterlab-dat/src/css.ts
@@ -10,6 +10,7 @@ export const CSS = {
     notebookSubscribe: 'jp-DatHexagonNotebookSubscribeIcon'
   } as { [key: string]: string },
   ICON_NAMES: {
+    create: 'dat-create-new-dat',
     happy: 'dat-happy-dat',
     chat: 'dat-hexagon-chat',
     outlines: 'dat-hexagon-outlines',
@@ -22,6 +23,7 @@ export const CSS = {
   COLOR: {
     brand: 'jp-mod-dat-brand'
   },
+  PUBLISHER: 'jp-DatPublisher',
   PEER: 'jp-Dat-Peer',
   SELF: 'jp-mod-dat-peer-self',
   OTHER: 'jp-mod-dat-peer-other',

--- a/packages/jupyterlab-dat/src/plugin.ts
+++ b/packages/jupyterlab-dat/src/plugin.ts
@@ -10,7 +10,7 @@ import { IDatManager } from './tokens';
 import { ICONS } from './icons';
 import { DatBar } from './widget';
 import { CSS } from '.';
-import {Publisher} from './publisher';
+import { Publisher } from './publisher';
 
 const extension: JupyterFrontEndPlugin<IDatManager> = {
   id: 'jupyterlab-dat',
@@ -26,7 +26,7 @@ const extension: JupyterFrontEndPlugin<IDatManager> = {
     bar.title.icon = CSS.ICON_NAMES.outlines;
     app.shell.add(bar, 'left');
     const publisher = new Publisher();
-    manager.addSidebarItem(publisher, {rank: 2});
+    manager.addSidebarItem(publisher, { rank: 2 });
     return manager;
   }
 };

--- a/packages/jupyterlab-dat/src/plugin.ts
+++ b/packages/jupyterlab-dat/src/plugin.ts
@@ -10,6 +10,7 @@ import { IDatManager } from './tokens';
 import { ICONS } from './icons';
 import { DatBar } from './widget';
 import { CSS } from '.';
+import {Publisher} from './publisher';
 
 const extension: JupyterFrontEndPlugin<IDatManager> = {
   id: 'jupyterlab-dat',
@@ -24,6 +25,8 @@ const extension: JupyterFrontEndPlugin<IDatManager> = {
     bar.title.caption = 'dat';
     bar.title.icon = CSS.ICON_NAMES.outlines;
     app.shell.add(bar, 'left');
+    const publisher = new Publisher();
+    manager.addSidebarItem(publisher, {rank: 2});
     return manager;
   }
 };

--- a/packages/jupyterlab-dat/src/plugin.ts
+++ b/packages/jupyterlab-dat/src/plugin.ts
@@ -26,6 +26,11 @@ const extension: JupyterFrontEndPlugin<IDatManager> = {
     bar.title.icon = CSS.ICON_NAMES.outlines;
     app.shell.add(bar, 'left');
     const publisher = new Publisher();
+    publisher.model = new Publisher.Model({
+      datManager: manager,
+      icons,
+      datTypes: []
+    });
     manager.addSidebarItem(publisher, { rank: 2 });
     return manager;
   }

--- a/packages/jupyterlab-dat/src/publisher.tsx
+++ b/packages/jupyterlab-dat/src/publisher.tsx
@@ -13,7 +13,6 @@ import { IDatManager } from './tokens';
 export class Publisher extends VDomRenderer<Publisher.Model<Widget>> {
   constructor() {
     super();
-    this.addClass(CSS.PANEL);
     this.addClass(CSS.PUBLISHER);
     this.title.icon = CSS.ICON_NAMES.create;
     this.title.label = 'publish';
@@ -22,8 +21,12 @@ export class Publisher extends VDomRenderer<Publisher.Model<Widget>> {
   protected render() {
     const m = this.model;
 
+    if (!m) {
+      return <div>Nothing to publish &emdash; yet.</div>;
+    }
+
     return (
-      <div className={`${CSS.PUBLISHER}-Main`}>
+      <div className={`${CSS.PUBLISHER}-Main ${CSS.PANEL}`}>
         <section>
           {this.renderPublishInfo()}
           {this.renderInfoForm()}
@@ -36,7 +39,7 @@ export class Publisher extends VDomRenderer<Publisher.Model<Widget>> {
             }
           })}
           {renderBigButton({
-            icon: CSS.ICON_NAMES.notebookPublish,
+            icon: m.icon,
             label: m.isPublishing ? 'PUBLISHING' : 'PUBLISH',
             icons: m.icons,
             className: m.isPublishing ? '' : CSS.JP.accept,
@@ -73,55 +76,70 @@ export class Publisher extends VDomRenderer<Publisher.Model<Widget>> {
   renderInfoForm() {
     const m = this.model;
 
-    return (
-      <details>
-        <summary>Manifest</summary>
-        <label>
-          <i>Title</i>
-          <input
-            defaultValue={m.title}
-            className={CSS.JP.styled}
-            onChange={evt => (m.title = evt.currentTarget.value)}
-          />
-        </label>
-        <label>
-          <i>Author</i>
-          <input
-            defaultValue={m.author}
-            className={CSS.JP.styled}
-            onChange={evt => (m.author = evt.currentTarget.value)}
-          />
-        </label>
-        <label>
-          <i>Description</i>
-          <textarea
-            defaultValue={m.description}
-            className={CSS.JP.styled}
-            onChange={evt => (m.description = evt.currentTarget.value)}
-            rows={5}
-          />
-        </label>
-      </details>
-    );
+    return [
+      <p>
+        <label>Title</label>
+        <input
+          type="text"
+          defaultValue={m.title}
+          className={CSS.JP.styled}
+          onChange={evt => (m.title = evt.currentTarget.value)}
+        />
+      </p>,
+      <p>
+        <label>Author</label>
+        <input
+          type="text"
+          defaultValue={m.author}
+          className={CSS.JP.styled}
+          onChange={evt => (m.author = evt.currentTarget.value)}
+        />
+      </p>,
+      <p>
+        <label>Description</label>
+        <textarea
+          defaultValue={m.description}
+          className={CSS.JP.styled}
+          onChange={evt => (m.description = evt.currentTarget.value)}
+          rows={5}
+        />
+      </p>
+    ];
   }
 }
 
 export namespace Publisher {
+  export interface IOptions {
+    icons: IIconRegistry;
+    datManager: IDatManager;
+    contentLabel?: string;
+    icon?: string;
+    datTypes: IDatManager.IDatType[];
+  }
+
   export class Model<T extends Widget> extends VDomModel {
     protected _icons: IIconRegistry;
     protected _datManager: IDatManager;
-    protected _datTypes: IDatManager.IDatType[];
-    protected _contentLabel: string;
-    protected _icon: string;
+    protected _datTypes: IDatManager.IDatType[] = [];
 
-    protected _status: string;
+    protected _contentLabel: string = 'Unknown';
+    protected _icon: string = 'dat-create-new-dat';
 
-    protected _title: string;
-    protected _description: string;
-    protected _author: string;
+    protected _status: string = 'zzz';
+
+    protected _title: string = '';
+    protected _description: string = '';
+    protected _author: string = '';
     protected _archive: dat.IDatArchive;
-    protected _url: string;
+    protected _url: string = '';
     protected _info: dat.IDatArchive.IArchiveInfo;
+
+    constructor(options: IOptions) {
+      super();
+      this._icons = options.icons;
+      this._datManager = options.datManager;
+      this._datTypes = options.datTypes;
+    }
 
     // readonly-ish
     get contentLabel() {

--- a/packages/jupyterlab-dat/src/publisher.tsx
+++ b/packages/jupyterlab-dat/src/publisher.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
-import {
-  renderInfoTable,
-  renderBigButton,
-  renderDatURL
-} from '@deathbeds/jupyterlab-dat/lib/fragments';
+import { renderInfoTable, renderBigButton, renderDatURL } from './fragments';
 
 import { VDomRenderer, VDomModel } from '@jupyterlab/apputils';
 
@@ -15,12 +11,12 @@ import { IIconRegistry } from '@jupyterlab/ui-components';
 import { IDatManager } from './tokens';
 
 export class Publisher extends VDomRenderer<Publisher.Model<Widget>> {
-  constructor () {
+  constructor() {
     super();
     this.addClass(CSS.PANEL);
     this.addClass(CSS.PUBLISHER);
     this.title.icon = CSS.ICON_NAMES.create;
-    this.title.label = "publish";
+    this.title.label = 'publish';
   }
 
   protected render() {

--- a/packages/jupyterlab-dat/src/publisher.tsx
+++ b/packages/jupyterlab-dat/src/publisher.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+
+import {
+  renderInfoTable,
+  renderBigButton,
+  renderDatURL
+} from '@deathbeds/jupyterlab-dat/lib/fragments';
+
+import { VDomRenderer, VDomModel } from '@jupyterlab/apputils';
+
+import { CSS } from '.';
+import { Widget } from '@phosphor/widgets';
+import { dat } from '@deathbeds/dat-sdk-webpack';
+import { IIconRegistry } from '@jupyterlab/ui-components';
+import { IDatManager } from './tokens';
+
+export class Publisher extends VDomRenderer<Publisher.Model<Widget>> {
+  constructor () {
+    super();
+    this.addClass(CSS.PANEL);
+    this.addClass(CSS.PUBLISHER);
+    this.title.icon = CSS.ICON_NAMES.create;
+    this.title.label = "publish";
+  }
+
+  protected render() {
+    const m = this.model;
+
+    return (
+      <div className={`${CSS.PUBLISHER}-Main`}>
+        <section>
+          {this.renderPublishInfo()}
+          {this.renderInfoForm()}
+        </section>
+        <footer>
+          {renderDatURL({
+            url: m.url,
+            props: {
+              readOnly: true
+            }
+          })}
+          {renderBigButton({
+            icon: CSS.ICON_NAMES.notebookPublish,
+            label: m.isPublishing ? 'PUBLISHING' : 'PUBLISH',
+            icons: m.icons,
+            className: m.isPublishing ? '' : CSS.JP.accept,
+            props: {
+              onClick: this.onPublish,
+              disabled: !m.canPublish
+            }
+          })}
+        </footer>
+      </div>
+    );
+  }
+
+  onPublish = async () => await this.model.publish().catch(console.warn);
+
+  renderPublishInfo() {
+    const m = this.model;
+    if (m.isPublishing && m.info) {
+      return renderInfoTable(m.info);
+    } else {
+      return (
+        <blockquote>
+          <i>
+            Publish the full contents of this {m.contentLabel} with the DAT
+            peer-to-peer network as JSON fragments. Send the link to anybody
+            with
+            <code>jupyterlab-dat</code>.
+          </i>
+        </blockquote>
+      );
+    }
+  }
+
+  renderInfoForm() {
+    const m = this.model;
+
+    return (
+      <details>
+        <summary>Manifest</summary>
+        <label>
+          <i>Title</i>
+          <input
+            defaultValue={m.title}
+            className={CSS.JP.styled}
+            onChange={evt => (m.title = evt.currentTarget.value)}
+          />
+        </label>
+        <label>
+          <i>Author</i>
+          <input
+            defaultValue={m.author}
+            className={CSS.JP.styled}
+            onChange={evt => (m.author = evt.currentTarget.value)}
+          />
+        </label>
+        <label>
+          <i>Description</i>
+          <textarea
+            defaultValue={m.description}
+            className={CSS.JP.styled}
+            onChange={evt => (m.description = evt.currentTarget.value)}
+            rows={5}
+          />
+        </label>
+      </details>
+    );
+  }
+}
+
+export namespace Publisher {
+  export class Model<T extends Widget> extends VDomModel {
+    protected _icons: IIconRegistry;
+    protected _datManager: IDatManager;
+    protected _datTypes: IDatManager.IDatType[];
+    protected _contentLabel: string;
+    protected _icon: string;
+
+    protected _status: string;
+
+    protected _title: string;
+    protected _description: string;
+    protected _author: string;
+    protected _archive: dat.IDatArchive;
+    protected _url: string;
+    protected _info: dat.IDatArchive.IArchiveInfo;
+
+    // readonly-ish
+    get contentLabel() {
+      return this._contentLabel;
+    }
+
+    get url() {
+      return this._url;
+    }
+
+    get icon() {
+      return this._icon;
+    }
+
+    get isPublishing() {
+      return !!this._url;
+    }
+
+    get info() {
+      return this._info;
+    }
+
+    get icons() {
+      return this._icons;
+    }
+
+    get canPublish() {
+      return !this._url;
+    }
+    get datTypes() {
+      return this._datTypes;
+    }
+
+    // read/write
+    get author() {
+      return this._author;
+    }
+    set author(author) {
+      this._author = author;
+      this.stateChanged.emit(void 0);
+      if (this._archive) {
+        this._archive.configure({ author }).catch(console.warn);
+      }
+    }
+
+    get description() {
+      return this._description;
+    }
+    set description(description) {
+      this._description = description;
+      this.stateChanged.emit(void 0);
+      if (this._archive) {
+        this._archive.configure({ description }).catch(console.warn);
+      }
+    }
+
+    get title() {
+      return this._title;
+    }
+    set title(title) {
+      this._title = title;
+      this.stateChanged.emit(void 0);
+      if (this._archive) {
+        this._archive.configure({ title }).catch(console.warn);
+      }
+    }
+
+    get status() {
+      return this._status;
+    }
+    set status(status) {
+      this._status = status;
+      this.stateChanged.emit(void 0);
+    }
+
+    /** the rest to be implemented by subclasses */
+    async publish() {
+      this.status = 'sharing';
+      const { title, description, author } = this;
+
+      this._archive = await this._datManager.create({
+        type: this._datTypes.map(type => type.name),
+        title,
+        description,
+        author
+      });
+    }
+  }
+}

--- a/packages/jupyterlab-dat/style/index.css
+++ b/packages/jupyterlab-dat/style/index.css
@@ -152,3 +152,10 @@ button.jp-mod-styled.jp-mod-dat-btn-big {
   border-left: solid 4px var(--jp-border-color1);
   padding: var(--jp-notebook-padding);
 }
+
+/* the publisher */
+.jp-DatPublisher {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true,
     "strict": true,
     "strictNullChecks": false,
+    "sourceMap": true,
     "target": "es2017",
     "types": []
   }


### PR DESCRIPTION
Having notebook pub/sub be one, special thing is weird. This will move the behavior over to the dat bar and make it listen to trackers, exposing one or more customizable panel per content type/sharing approach.